### PR TITLE
change invalid declaration with valid css

### DIFF
--- a/themes/default/css/styles.less
+++ b/themes/default/css/styles.less
@@ -160,7 +160,7 @@ article {
 		list-style-type: disc;
 	}
 	ol {
-		list-style-type: numeric;
+		list-style-type: decimal;
 		margin: 5px 5px 10px 35px;
 	}
 	ol, ul, dl {


### PR DESCRIPTION
I need a valid list-style-type of ordered list, so I changed the corresponding line.
