### PR TITLE
Fix for issue #21

### DIFF
--- a/src/MarkedProcessor.js
+++ b/src/MarkedProcessor.js
@@ -60,10 +60,18 @@ renderer.link = function (href, title, text) {
 			var page = renderer.doc.getPage(pfile);
 			if(page) {
 				// A cross page link. Replace
-				var pagename = page.getOutputFile();
-				if(pagename == 'index.html')
-					pagename = './';
-				href = href.replace(encodeURI(filename), pagename);
+				if(renderer.doc.isSinglePage()) {
+					if(href.indexOf('#') < 0) {
+						// We're not linking to a specific ID, so link to the section
+						var pagename = '#page-' + page.getID();
+					}
+				} else {
+					var pagename = page.getOutputFile();
+					if(pagename == 'index.html')
+						pagename = './';
+					pagename = href.replace(encodeURI(filename), pagename);
+				}
+				href = pagename;
 			} else {
 				// A non page link
 				var asset = renderer.doc.addAsset(filename);

--- a/src/Page.js
+++ b/src/Page.js
@@ -42,6 +42,10 @@ Page.prototype.setTitle = function (title) {
 	return this;
 };
 
+Page.prototype.getID = function () {
+	return this.__htmlName.toLowerCase().replace(/\.html$/, '').replace(/[^\w]+/g,'-');
+};
+
 Page.prototype.getIDs = function () {
 	return this.__ids;
 };

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -45,7 +45,8 @@ MarkDocTheme.prototype.renderContent = function (md, page) {
 		return this.__render(this.__content, {'Content':marked(md)});
 	else
 		return rsvp.Promise(function (res) {
-				res("\t\t<article>\n\t\t\t"+marked(md)+"\n\t\t</article>");
+				var html = marked(md);
+				res("\t\t<article id=\"page-"+page.getID()+"\">\n\t\t\t"+html+"\n\t\t</article>");
 			});
 };
 MarkDocTheme.prototype.renderFooter = function (opts) {


### PR DESCRIPTION
Each markdown page now gets a unique ID assigned to it so that links can be generated to point to it. Note that this relys on themes if they choose to override the default content rendering template.
